### PR TITLE
Add chair marker files to view_hachi.launch

### DIFF
--- a/spot_viz/launch/view_hachi.launch
+++ b/spot_viz/launch/view_hachi.launch
@@ -1,3 +1,4 @@
 <launch>
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find spot_viz)/rviz/hachi.rviz" />
+  <node name="chair marker" pkg="spot_viz" type="chair_marker">
 </launch>

--- a/spot_viz/launch/view_hachi.launch
+++ b/spot_viz/launch/view_hachi.launch
@@ -1,4 +1,5 @@
 <launch>
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find spot_viz)/rviz/hachi.rviz" />
-  <node name="chair marker" pkg="spot_viz" type="chair_marker">
+  <node name="chair marker" pkg="spot_viz" type="chair_marker" />
+  <node name="apriltag detector" pkg="simple_scripts" type="apriltag_detector.py" />
 </launch>


### PR DESCRIPTION
This branch adds the `chair_marker` and `apriltag_detector` nodes to the `view_hachi.launch` launchfile, which eliminates the need to manually run those nodes when using RViz 